### PR TITLE
feat: Silverstripe 6 compatibility (3.0)

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,9 +12,9 @@ Display a quote with head shot, name and title
 
 ## Requirements
 
-* Silverstripe ^5
-* Silverstripe Elemental ^5
-* jonom/focuspoint ^5
+* Silverstripe ^6
+* Silverstripe Elemental ^6
+* jonom/focuspoint ^6
 
 ## Installation
 

--- a/composer.json
+++ b/composer.json
@@ -7,8 +7,7 @@
         "silverstripe",
         "CMS",
         "elemental",
-        "statistic",
-        "counter"
+        "quote"
     ],
     "authors": [
         {
@@ -18,12 +17,13 @@
         }
     ],
     "require": {
-        "dnadesign/silverstripe-elemental": "^5.0",
-        "jonom/focuspoint": "^5.0",
-        "silverstripe/framework": "^5"
+        "dnadesign/silverstripe-elemental": "^6",
+        "jonom/focuspoint": "^6.0",
+        "silverstripe/framework": "^6",
+        "silverstripe/vendor-plugin": "^3"
     },
     "require-dev": {
-        "silverstripe/recipe-testing": "^3"
+        "silverstripe/recipe-testing": "^4"
     },
     "minimum-stability": "dev",
     "prefer-stable": true,
@@ -34,11 +34,16 @@
         }
     },
     "config": {
+        "allow-plugins": {
+            "composer/installers": true,
+            "silverstripe/vendor-plugin": true,
+            "silverstripe/recipe-plugin": true
+        },
         "process-timeout": 600
     },
     "extra": {
         "branch-alias": {
-            "dev-master": "2.x-dev"
+            "dev-master": "3.x-dev"
         }
     }
 }

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,16 +1,16 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" bootstrap="vendor/silverstripe/cms/tests/bootstrap.php" colors="true" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd">
-    <coverage includeUncoveredFiles="true">
-        <include>
-            <directory suffix=".php">src/</directory>
-        </include>
-        <exclude>
-            <directory suffix=".php">tests/</directory>
-        </exclude>
-    </coverage>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:noNamespaceSchemaLocation="vendor/phpunit/phpunit/phpunit.xsd"
+         bootstrap="vendor/silverstripe/cms/tests/bootstrap.php"
+         colors="true">
     <testsuites>
         <testsuite name="Default">
             <directory>tests/</directory>
         </testsuite>
     </testsuites>
+    <source>
+        <include>
+            <directory suffix=".php">src/</directory>
+        </include>
+    </source>
 </phpunit>


### PR DESCRIPTION
## Summary

**BREAKING CHANGE**: Drop Silverstripe 5 support. Major version 3.0 requiring Silverstripe 6 only.

## Changes

- **composer.json**: `elemental ^6`, `focuspoint ^6`, `framework ^6`, `vendor-plugin ^3`
- **require-dev**: `recipe-testing ^4`
- **branch-alias**: `3.x-dev`
- **phpunit.xml.dist**: Update to PHPUnit 11 format
- **README.md**: Update requirements to SS6

## Version History

| Version | Silverstripe |
|---------|-------------|
| 3.x     | ^6          |
| 2.x     | ^5          |
| 1.x     | ^4          |
